### PR TITLE
fix: stop silently losing nginx log data on restart or send failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Your server will appear in the dashboard within 60 seconds.
 ### Nginx Access/Error Logs
 - Tails nginx access and error logs using the `watchdock` log format
 - Captures nginx's built-in `$request_id` per request when present in the format, letting the dashboard correlate a request with the exact `watchdock-errors` SDK event it produced (see [docs](https://watchdock.cc/docs/nginx-log-collection))
+- Read offsets are persisted to disk (`.nginx_positions.json` next to the config file) and only advance after a successful send, so a restart or a failed/oversized delivery never silently drops log lines — at most it retries and sends a few duplicates
 
 ---
 

--- a/agent.py
+++ b/agent.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from typing import List, Dict
 from config import Config
 
-AGENT_VERSION = "1.3.0"
+AGENT_VERSION = "1.3.1"
 
 try:
     import psutil

--- a/install.sh
+++ b/install.sh
@@ -114,6 +114,7 @@ setup_agent_files() {
     cp log_parser.py "$AGENT_DIR/"
     cp docker_monitor.py "$AGENT_DIR/"
     cp container_log_collector.py "$AGENT_DIR/"
+    cp nginx_log_collector.py "$AGENT_DIR/"
     cp requirements.txt "$AGENT_DIR/"
 
     # Make agent executable

--- a/nginx_log_collector.py
+++ b/nginx_log_collector.py
@@ -5,11 +5,12 @@ Tails nginx access and error log files, parses lines using the watchdock log for
 and sends raw per-request access events and error events to WatchDock.
 """
 
+import json
 import logging
 import os
 import re
 from datetime import datetime, timezone
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 import requests
@@ -32,20 +33,55 @@ ERROR_LOG_RE = re.compile(
     r'^(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) \[(\w+)\] \d+#\d+: (?:\*\d+ )?(.+)$'
 )
 
+# Cap on events per POST so a large backlog (e.g. after a restart with no persisted
+# state, or recovering from an extended backend outage) can't produce a payload big
+# enough to get rejected with 413, which would otherwise drop the whole batch.
+MAX_EVENTS_PER_BATCH = 200
+
 
 class NginxLogCollector:
     """
     Reads nginx access and error log files for each configured NginxLogSource,
     parses new lines since the last collection, and sends raw per-request events
     and error events to the WatchDock backend.
+
+    File read offsets are persisted to disk and only advanced after a
+    successful send, so a process restart or a failed/oversized send never
+    silently drops log lines. When a path is shared by multiple sources
+    (e.g. filtered by different path prefixes), the offset for that path only
+    advances once every source that reads it has sent successfully — a
+    partial failure just means some events get retried next cycle rather
+    than lost.
     """
 
     def __init__(self, config):
         self.config = config
         self.logger = logging.getLogger(__name__)
-        # Byte offsets keyed by file path. Each unique path is read once per
-        # cycle and its lines distributed to all sources that reference it.
-        self._file_positions: Dict[str, int] = {}
+        self._state_path = self._resolve_state_path()
+        # Byte offsets keyed by file path, persisted across restarts.
+        self._file_positions: Dict[str, int] = self._load_positions()
+
+    def _resolve_state_path(self) -> str:
+        config_file = getattr(self.config, "config_file", "agent_config.json")
+        directory = os.path.dirname(os.path.abspath(config_file))
+        return os.path.join(directory, ".nginx_positions.json")
+
+    def _load_positions(self) -> Dict[str, int]:
+        try:
+            with open(self._state_path, "r") as f:
+                return json.load(f)
+        except FileNotFoundError:
+            return {}
+        except Exception as e:
+            self.logger.warning(f"Could not load persisted nginx file positions, starting fresh: {e}")
+            return {}
+
+    def _save_positions(self) -> None:
+        try:
+            with open(self._state_path, "w") as f:
+                json.dump(self._file_positions, f)
+        except Exception as e:
+            self.logger.warning(f"Could not persist nginx file positions: {e}")
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -55,15 +91,19 @@ class NginxLogCollector:
         """
         Called once per nginx_interval. For every configured NginxLogSource,
         reads new lines from its access and error log files, parses them,
-        and sends to the backend.
+        and sends to the backend. A file's read offset only advances once
+        every source referencing it has sent its events successfully.
         """
         nginx_sources = self.config.get("nginx_sources", [])
         if not nginx_sources:
             return
 
-        # Read each unique file path exactly once per cycle.
-        access_lines_by_path: Dict[str, List[str]] = {}
-        error_lines_by_path: Dict[str, List[str]] = {}
+        # Read each unique file path exactly once per cycle. Reading does not
+        # mutate self._file_positions yet — that only happens once we know
+        # every consumer of a path succeeded.
+        access_lines_by_path: Dict[str, Tuple[List[str], int]] = {}
+        error_lines_by_path: Dict[str, Tuple[List[str], int]] = {}
+        path_succeeded: Dict[str, bool] = {}
 
         for source in nginx_sources:
             for store, path in [
@@ -72,38 +112,59 @@ class NginxLogCollector:
             ]:
                 if path not in store:
                     store[path] = self._read_new_lines(path)
+                    path_succeeded[path] = True
 
         # Process each source with its collected lines.
         for source in nginx_sources:
             source_id = source["id"]
             prefix = source.get("filter_path_prefix", "")
 
-            access_lines = access_lines_by_path.get(source["access_log_path"], [])
+            access_path = source["access_log_path"]
+            access_lines, _ = access_lines_by_path.get(access_path, ([], 0))
             events = self._parse_access_lines(access_lines, prefix)
-            if events:
-                self._send_access_events(source_id, events)
+            if events and not self._send_access_events(source_id, events):
+                path_succeeded[access_path] = False
 
-            error_lines = error_lines_by_path.get(source["error_log_path"], [])
+            error_path = source["error_log_path"]
+            error_lines, _ = error_lines_by_path.get(error_path, ([], 0))
             error_events = self._parse_error_lines(error_lines)
-            if error_events:
-                self._send_error_events(source_id, error_events)
+            if error_events and not self._send_error_events(source_id, error_events):
+                path_succeeded[error_path] = False
+
+        # Commit offsets only for paths where every source that reads them
+        # sent successfully this cycle. Anything else is retried next cycle,
+        # which may re-send already-delivered events for other sources of a
+        # shared path — duplicates are an acceptable tradeoff for never
+        # silently losing data.
+        changed = False
+        for path, (_, new_position) in {**access_lines_by_path, **error_lines_by_path}.items():
+            if path_succeeded.get(path, True) and self._file_positions.get(path) != new_position:
+                self._file_positions[path] = new_position
+                changed = True
+
+        if changed:
+            self._save_positions()
 
     # ------------------------------------------------------------------
     # File reading
     # ------------------------------------------------------------------
 
-    def _read_new_lines(self, path: str) -> List[str]:
+    def _read_new_lines(self, path: str) -> Tuple[List[str], int]:
         """
         Read new lines from a log file since the last recorded offset.
         Handles log rotation by resetting to offset 0 when the file shrinks.
-        Returns an empty list if the file does not exist or cannot be read.
+        Returns (lines, candidate_new_offset) without committing the offset —
+        callers commit it only after a successful send. Returns ([], last
+        known offset) if the file does not exist or cannot be read, so a
+        transient read error never advances the persisted position.
         """
+        last_position = self._file_positions.get(path, 0)
+
         if not os.path.exists(path):
-            return []
+            return [], last_position
 
         try:
             current_size = os.path.getsize(path)
-            last_position = self._file_positions.get(path, 0)
 
             # Log rotation: file is smaller than our last position.
             if current_size < last_position:
@@ -112,7 +173,7 @@ class NginxLogCollector:
 
             # No new content.
             if current_size <= last_position:
-                return []
+                return [], last_position
 
             lines: List[str] = []
             with open(path, "r", errors="replace") as f:
@@ -121,13 +182,13 @@ class NginxLogCollector:
                     stripped = line.strip()
                     if stripped:
                         lines.append(stripped)
-                self._file_positions[path] = f.tell()
+                new_position = f.tell()
 
-            return lines
+            return lines, new_position
 
         except Exception as e:
             self.logger.error(f"Error reading nginx log file {path}: {e}")
-            return []
+            return [], last_position
 
     # ------------------------------------------------------------------
     # Access log parsing
@@ -228,34 +289,39 @@ class NginxLogCollector:
     # API calls
     # ------------------------------------------------------------------
 
-    def _send_access_events(self, source_id: str, events: List[dict]) -> None:
-        """POST raw per-request access events to the backend."""
-        try:
-            response = requests.post(
-                f"{self.config.get('api_endpoint')}/core/agent/nginx-access-events/",
-                json={"nginx_log_source_id": source_id, "events": events},
-                headers={
-                    "Authorization": f"Bearer {self.config.get('api_token')}",
-                    "Content-Type": "application/json",
-                },
-                timeout=30,
-            )
-            if response.status_code in (200, 201):
-                self.logger.debug(
-                    f"Nginx access events sent: {len(events)} events for source {source_id}"
-                )
-            else:
-                self.logger.warning(
-                    f"Failed to send nginx access events: {response.status_code} - {response.text}"
-                )
-        except Exception as e:
-            self.logger.error(f"Error sending nginx access events: {e}")
+    def _send_access_events(self, source_id: str, events: List[dict]) -> bool:
+        """POST raw per-request access events to the backend, chunked to stay
+        under any reasonable payload size limit. Returns True only if every
+        chunk was accepted."""
+        all_ok = True
+        for chunk in self._chunk(events):
+            if not self._post_events("nginx-access-events", source_id, chunk):
+                all_ok = False
+        return all_ok
 
-    def _send_error_events(self, source_id: str, events: List[dict]) -> None:
-        """POST parsed error events to the backend."""
+    def _send_error_events(self, source_id: str, events: List[dict]) -> bool:
+        """POST parsed error events to the backend, chunked the same way as
+        access events. Returns True only if every chunk was accepted."""
+        all_ok = True
+        for chunk in self._chunk(events):
+            if not self._post_events("nginx-error-events", source_id, chunk):
+                all_ok = False
+        return all_ok
+
+    @staticmethod
+    def _chunk(events: List[dict]) -> List[List[dict]]:
+        return [
+            events[i : i + MAX_EVENTS_PER_BATCH]
+            for i in range(0, len(events), MAX_EVENTS_PER_BATCH)
+        ] or [[]]
+
+    def _post_events(self, endpoint: str, source_id: str, events: List[dict]) -> bool:
+        if not events:
+            return True
+
         try:
             response = requests.post(
-                f"{self.config.get('api_endpoint')}/core/agent/nginx-error-events/",
+                f"{self.config.get('api_endpoint')}/core/agent/{endpoint}/",
                 json={"nginx_log_source_id": source_id, "events": events},
                 headers={
                     "Authorization": f"Bearer {self.config.get('api_token')}",
@@ -265,11 +331,14 @@ class NginxLogCollector:
             )
             if response.status_code in (200, 201):
                 self.logger.debug(
-                    f"Nginx error events sent: {len(events)} events for source {source_id}"
+                    f"Sent {len(events)} events to {endpoint} for source {source_id}"
                 )
-            else:
-                self.logger.warning(
-                    f"Failed to send nginx error events: {response.status_code} - {response.text}"
-                )
+                return True
+
+            self.logger.warning(
+                f"Failed to send {endpoint}: {response.status_code} - {response.text[:500]}"
+            )
+            return False
         except Exception as e:
-            self.logger.error(f"Error sending nginx error events: {e}")
+            self.logger.error(f"Error sending {endpoint}: {e}")
+            return False

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -108,6 +108,7 @@ cp config.py "$AGENT_DIR/"
 cp log_parser.py "$AGENT_DIR/"
 cp docker_monitor.py "$AGENT_DIR/" 2>/dev/null || true
 cp container_log_collector.py "$AGENT_DIR/" 2>/dev/null || true
+cp nginx_log_collector.py "$AGENT_DIR/" 2>/dev/null || true
 cp requirements.txt "$AGENT_DIR/"
 
 # Update VERSION file


### PR DESCRIPTION
Persists file read offsets and only advances them after a confirmed send (fixes silent data loss on restart/413/502). Also adds nginx_log_collector.py to install.sh/upgrade.sh's copy lists, which were both missing it.