### PR TITLE
chore: bump version to 1.3.3 (test auto-update fix)

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from typing import List, Dict
 from config import Config
 
-AGENT_VERSION = "1.3.2"
+AGENT_VERSION = "1.3.3"
 
 try:
     import psutil


### PR DESCRIPTION
Trivial version bump to test the auto-update fix end to end on prod without manual intervention.