### PR TITLE
chore: bump version to 1.3.5 (test detached auto-update fix)

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from typing import List, Dict
 from config import Config
 
-AGENT_VERSION = "1.3.4"
+AGENT_VERSION = "1.3.5"
 
 try:
     import psutil


### PR DESCRIPTION
Trivial version bump to test the systemd-run detach fix end to end on both prod servers without manual intervention.