### PR TITLE
chore: bump version to 1.3.6 (trace cascading restart)

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from typing import List, Dict
 from config import Config
 
-AGENT_VERSION = "1.3.5"
+AGENT_VERSION = "1.3.6"
 
 try:
     import psutil


### PR DESCRIPTION
Diagnostic test release.