### PR TITLE
Persistent agent_id: lossless upgrades, no cloned-machine-id collisions

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from typing import List, Dict
 from config import Config
 
-AGENT_VERSION = "1.3.9"
+AGENT_VERSION = "1.4.0"
 
 try:
     import psutil

--- a/config.py
+++ b/config.py
@@ -67,28 +67,49 @@ class Config:
 
     def get_machine_id(self) -> str:
         """
-        Get unique machine identifier. Tries multiple methods:
-        1. /etc/machine-id (Linux)
-        2. /var/lib/dbus/machine-id (Linux)
-        3. Generated UUID based on hostname + MAC address (fallback)
+        Return this agent's stable identity, used server-side as the LogSource key.
+
+        Resolution order:
+        1. agent_id persisted in the config. Once set, this is authoritative and
+           never changes, even if /etc/machine-id or the hostname later change.
+        2. Otherwise resolve the legacy identity exactly as older agents did
+           (/etc/machine-id, then /var/lib/dbus/machine-id, then a uuid5 of the
+           hostname) and persist it as agent_id.
+
+        Branch 2 is what makes upgrades lossless: an existing agent keeps reporting
+        the same string it always has, so its server-side record is preserved
+        rather than split into a new one. Fresh installs are seeded with a random
+        agent_id by the installer, so they take branch 1 and never collide with a
+        cloned machine-id.
         """
         if self._machine_id:
             return self._machine_id
 
-        # Try Linux machine-id files
-        machine_id_paths = ['/etc/machine-id', '/var/lib/dbus/machine-id']
-        for path in machine_id_paths:
+        stored = self.config.get("agent_id")
+        if stored:
+            self._machine_id = stored
+            return self._machine_id
+
+        self._machine_id = self._resolve_legacy_machine_id()
+        try:
+            self.set("agent_id", self._machine_id)  # persist so identity is pinned
+        except OSError as exc:
+            logger.warning("Could not persist agent_id to config: %s", exc)
+        return self._machine_id
+
+    def _resolve_legacy_machine_id(self) -> str:
+        """Reproduce the historical identity derivation for existing installs."""
+        for path in ('/etc/machine-id', '/var/lib/dbus/machine-id'):
             try:
                 with open(path, 'r') as f:
-                    self._machine_id = f.read().strip()
-                    return self._machine_id
+                    value = f.read().strip()
+                    if value:
+                        return value
             except (FileNotFoundError, PermissionError):
                 continue
 
-        # Fallback: Generate stable ID from hostname
-        hostname = self.get_hostname()
-        self._machine_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, hostname))
-        return self._machine_id
+        # Fallback: stable ID from hostname (matches older agent behaviour).
+        return str(uuid.uuid5(uuid.NAMESPACE_DNS, self.get_hostname()))
 
     def get_hostname(self) -> str:
         """Get the system hostname"""

--- a/install-from-url.sh
+++ b/install-from-url.sh
@@ -66,10 +66,21 @@ cd watchdock-agent-*/
 
 # Create config
 log "Creating configuration..."
+# Give every fresh install its own random identity so that a box cloned from a
+# snapshot cannot share another server's machine-id. Existing installs keep
+# their identity via the agent's own adoption logic (see config.get_machine_id).
+if [[ -r /proc/sys/kernel/random/uuid ]]; then
+  AGENT_ID="$(cat /proc/sys/kernel/random/uuid)"
+elif command -v uuidgen >/dev/null 2>&1; then
+  AGENT_ID="$(uuidgen)"
+else
+  AGENT_ID="$(python3 -c 'import uuid; print(uuid.uuid4())')"
+fi
 cat > agent_config.json << EOF
 {
   "api_endpoint": "https://api.watchdock.cc/api",
   "api_token": "${API_TOKEN}",
+  "agent_id": "${AGENT_ID}",
   "log_files": [],
   "collect_metrics": true,
   "metrics_interval": 300,


### PR DESCRIPTION
## Why
Agent identity was read live from `/etc/machine-id` on every run (`Config.get_machine_id`). Two problems:
- A VM cloned from a snapshot/AMI inherits the same `/etc/machine-id`, so both boxes report the same identity and collapse into one server record on the backend. The second box becomes invisible (see the "Agent identity collisions" wiki + the Impact Africa cleanup).
- There was no stable, agent-owned identity we control.

## What
Introduce a persistent `agent_id` in `agent_config.json` and make it the source of truth.

`get_machine_id()` now resolves in this order:
1. **`agent_id` from config** — authoritative once set; never changes even if `/etc/machine-id` or the hostname later change.
2. **Legacy derivation, then pin it** — if there's no `agent_id` yet (an existing install being upgraded), reproduce the *exact* old logic (`/etc/machine-id` → `/var/lib/dbus/machine-id` → `uuid5(hostname)`) and persist the result as `agent_id`.

Fresh installs are seeded with a random `agent_id` (uuid4) by `install-from-url.sh`, so they take branch 1 from the very first run and can't collide with a cloned machine-id.

## Why this is lossless on upgrade
An upgraded agent keeps sending the byte-for-byte identity it always sent (branch 2 reproduces the full legacy chain, including the hostname fallback, so boxes that never had `/etc/machine-id` are covered too). The backend keeps matching the same `LogSource`. No new record, no split history, no data migration. `machine_id` is already an opaque `CharField`, so a UUID is just another value in the same column — no schema change.

**Deliberately not touching `upgrade.sh`:** only the agent knows the full legacy resolution (an installer that reads only `/etc/machine-id` would pin the wrong value for hostname-fallback boxes). Adoption happens at runtime in `config.py`, once, on first run of the new agent.

## Honest limitation
This closes collisions for boxes provisioned by running the installer per box. It does **not** fully fix full-disk snapshot/AMI clones: those copy `agent_config.json` too, so the seeded `agent_id` is inherited just like `/etc/machine-id` was. Covering that needs the image-bake step to clear `agent_id` (worth documenting in RELEASING/runbook), or a later change to detect an environment change and regenerate.

## Tests
Exercised `config.get_machine_id()` across four cases (stored id wins and isn't overwritten; missing id resolves + persists; identity stable across reloads; adopts + pins a present `/etc/machine-id`). `install-from-url.sh` passes `bash -n` and emits valid JSON with a uuid4 `agent_id`. No test suite exists in this repo yet.